### PR TITLE
Add Playwright MCP server to Claude Code and Codex

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,14 @@
   "enabledPlugins": {
     "rust-analyzer-lsp@claude-plugins-official": true
   },
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ]
+    }
+  },
   "permissions": {
     "allow": [
       "Bash(git *)",

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+[mcp_servers.playwright]
+command = "npx"
+args = ["@playwright/mcp@latest"]


### PR DESCRIPTION
## Summary

Adds [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) as an MCP server for both Claude Code and Codex CLI. Playwright MCP provides browser automation via structured accessibility snapshots — no vision model needed.

## Changes

- **`.claude/settings.json`** — Added `mcpServers.playwright` config (`npx @playwright/mcp@latest`)
- **`.codex/config.toml`** — New file with `[mcp_servers.playwright]` config

## References

- https://github.com/microsoft/playwright-mcp