### PR TITLE
Add brainstorming, planning, and debugging skills from obra/superpowers

### DIFF
--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -1,0 +1,66 @@
+# Adapted from obra/superpowers (MIT) — https://github.com/obra/superpowers
+
+---
+name: brainstorming
+description: Use before any non-trivial feature work — new modules, architectural changes, or multi-file modifications. Explores intent, requirements, and design before implementation.
+---
+
+# Brainstorming Ideas Into Designs
+
+## Overview
+
+Help turn ideas into designs through collaborative dialogue. Understand the project context, ask clarifying questions, then present a design for approval before writing code.
+
+**Do NOT start coding until you have a design and the user has approved it.**
+
+This applies to non-trivial work — if someone asks for a one-line fix, use your judgment.
+
+## Process
+
+### 1. Explore Context
+
+- Check relevant files, tests, recent commits
+- Understand the current state of the codebase
+- For Rust crates: check `Cargo.toml`, existing module structure, public API
+
+### 2. Ask Clarifying Questions
+
+- One question at a time — don't overwhelm
+- Prefer multiple-choice when possible
+- Focus on: purpose, constraints, success criteria, scope
+- Ask about edge cases and error handling early
+
+### 3. Propose Approaches
+
+- Present 2-3 approaches with trade-offs
+- Lead with your recommendation and explain why
+- Apply YAGNI — remove unnecessary scope ruthlessly
+
+### 4. Present Design
+
+- Scale to complexity: a few sentences for small features, detailed breakdown for large ones
+- Cover: module structure, public API, data flow, error handling, testing approach
+- For Rust: specify which files to create/modify, new structs/traits, public functions
+- Get approval before proceeding
+
+### 5. Document (optional)
+
+For significant features, save the design:
+- As a GitHub issue with the plan
+- Or as `notes/<topic>.md` in the repo
+- Skip this for small/medium features — the conversation is the record
+
+### 6. Transition to Implementation
+
+Once approved, either:
+- Start implementing directly (for focused work)
+- Create a plan with task breakdown (for larger work — see `planning` skill)
+- Spawn sub-agents with clear task descriptions (for parallel work)
+
+## Key Principles
+
+- **One question at a time** — don't overwhelm
+- **YAGNI ruthlessly** — remove unnecessary features from all designs
+- **Explore alternatives** — always consider at least 2 approaches
+- **Be flexible** — the design will evolve during implementation, and that's fine
+- **Right-size the process** — a config change doesn't need the same rigor as a new module

--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,0 +1,108 @@
+# Adapted from obra/superpowers (MIT) — https://github.com/obra/superpowers
+
+---
+name: debugging
+description: Use when encountering any bug, test failure, or unexpected behavior. Systematic root cause analysis before proposing fixes.
+---
+
+# Systematic Debugging
+
+## Overview
+
+Random fixes waste time and create new bugs. **Always find root cause before attempting fixes.**
+
+## The Iron Law
+
+```
+NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+```
+
+If you haven't completed Phase 1, you cannot propose fixes.
+
+## The Four Phases
+
+### Phase 1: Root Cause Investigation
+
+**BEFORE attempting ANY fix:**
+
+1. **Read error messages carefully**
+   - Don't skip past errors or warnings
+   - Read stack traces completely — they often contain the answer
+   - Note line numbers, file paths, error codes
+
+2. **Reproduce consistently**
+   - Can you trigger it reliably?
+   - What are the exact steps / test command?
+   - For Rust: `cargo test <specific_test> -- --nocapture` to see output
+
+3. **Check recent changes**
+   - `git diff`, recent commits
+   - New dependencies, Cargo.toml changes
+   - Any `unsafe` blocks or `.unwrap()` calls nearby?
+
+4. **Trace data flow**
+   - Where does the bad value originate?
+   - Trace backward through the call stack
+   - Fix at source, not at symptom
+
+### Phase 2: Pattern Analysis
+
+1. **Find working examples** — similar working code in the same codebase
+2. **Compare** — what's different between working and broken?
+3. **List every difference** — don't assume "that can't matter"
+4. **Check types** — in Rust, type mismatches and ownership issues are common root causes
+
+### Phase 3: Hypothesis and Testing
+
+1. **Form a single hypothesis** — "I think X is the root cause because Y"
+2. **Test minimally** — smallest possible change, one variable at a time
+3. **Verify** — did it work? If not, form a NEW hypothesis. Don't stack fixes.
+
+**If 3+ fixes have failed:** Stop. The issue is likely architectural, not a simple bug. Discuss with the user before attempting more fixes.
+
+### Phase 4: Implementation
+
+1. **Write a failing test** that demonstrates the bug
+2. **Implement the fix** — address root cause, not symptom
+3. **Verify** — test passes, no other tests broken
+4. **`cargo clippy`** — ensure no new warnings
+
+## Red Flags — Stop and Return to Phase 1
+
+If you catch yourself thinking:
+- "Quick fix for now, investigate later"
+- "Just try changing X and see if it works"
+- "I don't fully understand but this might work"
+- "Let me fix multiple things at once"
+- Proposing solutions before tracing data flow
+
+**ALL of these mean: STOP. Return to Phase 1.**
+
+## Rust-Specific Debugging
+
+| Situation | First Step |
+|-----------|-----------|
+| `cargo test` failure | Run the specific failing test with `-- --nocapture` |
+| Compilation error | Read the full error — Rust compiler messages are excellent |
+| Borrow checker error | Draw the ownership/lifetime diagram before "fixing" |
+| `unwrap()` panic | Find which `.unwrap()` panicked, understand why the value is `None`/`Err` |
+| Clippy warning | Read the suggested fix — clippy is almost always right |
+| CI failure but local passes | Check Rust version, feature flags, OS differences |
+
+## Quick Reference
+
+| Phase | Key Activity | Done When |
+|-------|-------------|-----------|
+| 1. Root Cause | Read errors, reproduce, trace data | Understand WHAT and WHY |
+| 2. Pattern | Find working examples, compare | Identified the difference |
+| 3. Hypothesis | Form theory, test one change | Confirmed or new theory |
+| 4. Fix | Write test, fix, verify | Bug resolved, all tests pass, clippy clean |
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Issue is simple, don't need process" | Simple issues have root causes. Process is fast for simple bugs. |
+| "Emergency, no time" | Systematic is FASTER than guess-and-check thrashing. |
+| "Just try this first" | First fix sets the pattern. Do it right from the start. |
+| "Multiple fixes at once saves time" | Can't isolate what worked. Causes new bugs. |

--- a/.claude/skills/planning/SKILL.md
+++ b/.claude/skills/planning/SKILL.md
@@ -1,0 +1,99 @@
+# Adapted from obra/superpowers (MIT) — https://github.com/obra/superpowers
+
+---
+name: planning
+description: Use when you have a spec or requirements for a multi-step task, before touching code. Breaks work into clear, actionable tasks.
+---
+
+# Writing Implementation Plans
+
+## Overview
+
+Break approved designs into concrete, actionable tasks. Each task should be clear enough that a sub-agent (or future-you with no context) can execute it without ambiguity.
+
+**Announce at start:** "Creating an implementation plan for [feature]."
+
+## When to Use
+
+- Feature requires changes across multiple files or modules
+- Work will be split across sub-agents
+- Task is complex enough that jumping in would lead to rework
+- You want human checkpoints between phases
+
+Skip this for single-file changes or obvious implementations.
+
+## Task Structure
+
+Each task should include:
+
+```markdown
+### Task N: [Clear Name]
+
+**Files:**
+- Create: `src/module.rs`
+- Modify: `src/lib.rs` (add `pub mod module;`)
+- Test: `tests/module_tests.rs` or inline `#[cfg(test)]`
+
+**What to do:**
+[Specific description — what structs, functions, traits to add. Include key signatures.]
+
+**Verification:**
+- `cargo test` passes
+- `cargo clippy` clean
+- [Any specific behavior to verify]
+
+**Commit:** `Add module with [feature]`
+```
+
+## Task Sizing
+
+- Target **5-15 minutes** per task for sub-agent work
+- Larger tasks (30+ min) are fine for focused human work
+- Each task should be independently committable
+- If a task feels too big, split it
+
+## Plan Document
+
+For significant features, save the plan:
+
+```markdown
+# [Feature Name] Implementation Plan
+
+**Goal:** [One sentence]
+**Crate:** [which crate/repo]
+**Branch:** [branch name]
+
+---
+
+### Task 1: ...
+### Task 2: ...
+```
+
+Save to: GitHub issue body, or `notes/<feature>-plan.md` in the repo.
+
+## Rust-Specific Guidance
+
+- Specify exact `pub` vs private visibility
+- Include `use` imports that will be needed
+- Note any `Cargo.toml` dependency additions
+- Specify whether tests are unit (`#[cfg(test)]` in module) or integration (`tests/`)
+- Include `cargo clippy` as a verification step on every task
+- For new public API: include doc comments in the plan
+
+## Execution
+
+After saving the plan, offer:
+
+1. **Sequential** — work through tasks in order, commit after each
+2. **Sub-agents** — spawn one sub-agent per task (or group of related tasks)
+3. **Human review** — present plan for approval, then execute with checkpoints
+
+Match the approach to the scope: sub-agents for large batch work, sequential for focused sessions.
+
+## Key Principles
+
+- **Exact file paths** — no ambiguity about where changes go
+- **Complete enough to execute** — don't write "add validation" when you mean "add `validate()` that checks X, Y, Z"
+- **DRY** — if multiple tasks need the same setup, do it once in Task 1
+- **Tests with every task** — not necessarily test-first, but every task includes its tests
+- **Frequent commits** — one commit per task, clean history


### PR DESCRIPTION
Surgical adoption of 3 skills from [obra/superpowers](https://github.com/obra/superpowers) (MIT licensed), copied by value and modified for our workflow.

## What's added

| Skill | Source | Modifications |
|-------|--------|--------------|
| **brainstorming** | `skills/brainstorming` | Removed hard-gate rigidity, right-sized for small vs large features, added Rust-specific guidance |
| **planning** | `skills/writing-plans` | Renamed, adjusted task sizing from 2-5 min to 5-15 min, removed strict TDD-first, added Rust/cargo specifics |
| **debugging** | `skills/systematic-debugging` | Kept 4-phase structure, added Rust-specific debugging table, removed plugin cross-references |

## What's NOT included (and why)

- **test-driven-development** — too opinionated (deletes code written before tests)
- **using-git-worktrees** — already covered by `ga`/`gd` + `git-push-pr`
- **subagent-driven-development** — OpenClaw handles this
- **executing-plans** / **finishing-a-development-branch** — covered by existing skills

## Approach

Same pattern as shaping skills from rjs/shaping-skills: copied by value, not referenced. Attribution comment at top of each file.

Closes #15