### PR TITLE
Add cross-platform tool installer

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -7,8 +7,6 @@
 # ──────────────────────────────────────────────
 brew "jq"           # JSON processor
 brew "gh"           # GitHub CLI
-brew "gum"          # Interactive shell scripts
-brew "lazygit"      # Terminal git UI (Go)
 brew "neovim"       # Editor
 brew "shellcheck"   # Shell script linter
 

--- a/Brewfile
+++ b/Brewfile
@@ -1,39 +1,28 @@
-# Brewfile — Declarative package list for macOS
+# Brewfile — Minimal macOS packages (non-Rust tools only)
 # Usage: brew bundle [--file=Brewfile]
-# Docs: https://github.com/Homebrew/homebrew-bundle
+# Rust CLI tools live in cargo-tools.txt (installed via cargo install)
 
 # ──────────────────────────────────────────────
-# Core CLI Tools
+# System tools (no cargo equivalent)
 # ──────────────────────────────────────────────
-brew "eza"          # Modern ls replacement
-brew "bat"          # Cat with syntax highlighting
-brew "git-delta"    # Beautiful git diffs
-brew "zoxide"       # Smart cd (z)
-brew "just"         # Task runner
-brew "ripgrep"      # Fast grep (rg)
-brew "lazygit"      # Terminal git UI
-brew "gum"          # Interactive shell scripts
-brew "fd"           # Fast find
 brew "jq"           # JSON processor
-
-# ──────────────────────────────────────────────
-# Development Tools
-# ──────────────────────────────────────────────
 brew "gh"           # GitHub CLI
+brew "gum"          # Interactive shell scripts
+brew "lazygit"      # Terminal git UI (Go)
 brew "neovim"       # Editor
 brew "shellcheck"   # Shell script linter
-brew "watchexec"    # File watcher
 
 # ──────────────────────────────────────────────
 # Casks (GUI Applications)
 # ──────────────────────────────────────────────
-# cask "ghostty"    # Terminal emulator (uncomment if available in Homebrew)
+# cask "ghostty"    # Terminal emulator (uncomment if available)
 
 # ──────────────────────────────────────────────
-# Not in Homebrew — installed separately:
-#   rustup    → curl https://sh.rustup.rs
-#   nvm       → curl https://raw.githubusercontent.com/nvm-sh/nvm/...
-#   uv        → curl https://astral.sh/uv/install.sh
-#   oh-my-zsh → sh -c "$(curl ...ohmyz.sh/install.sh)"
-#   p10k      → git clone into $ZSH_CUSTOM/themes/
+# Installed via their own ecosystems:
+#   Rust CLI tools → cargo-tools.txt (bat, eza, delta, rg, fd, zoxide, just)
+#   rustup         → curl https://sh.rustup.rs
+#   nvm            → curl https://raw.githubusercontent.com/nvm-sh/nvm/...
+#   uv             → curl https://astral.sh/uv/install.sh
+#   oh-my-zsh      → sh -c "$(curl ...ohmyz.sh/install.sh)"
+#   p10k           → git clone into $ZSH_CUSTOM/themes/
 # ──────────────────────────────────────────────

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,39 @@
+# Brewfile — Declarative package list for macOS
+# Usage: brew bundle [--file=Brewfile]
+# Docs: https://github.com/Homebrew/homebrew-bundle
+
+# ──────────────────────────────────────────────
+# Core CLI Tools
+# ──────────────────────────────────────────────
+brew "eza"          # Modern ls replacement
+brew "bat"          # Cat with syntax highlighting
+brew "git-delta"    # Beautiful git diffs
+brew "zoxide"       # Smart cd (z)
+brew "just"         # Task runner
+brew "ripgrep"      # Fast grep (rg)
+brew "lazygit"      # Terminal git UI
+brew "gum"          # Interactive shell scripts
+brew "fd"           # Fast find
+brew "jq"           # JSON processor
+
+# ──────────────────────────────────────────────
+# Development Tools
+# ──────────────────────────────────────────────
+brew "gh"           # GitHub CLI
+brew "neovim"       # Editor
+brew "shellcheck"   # Shell script linter
+brew "watchexec"    # File watcher
+
+# ──────────────────────────────────────────────
+# Casks (GUI Applications)
+# ──────────────────────────────────────────────
+# cask "ghostty"    # Terminal emulator (uncomment if available in Homebrew)
+
+# ──────────────────────────────────────────────
+# Not in Homebrew — installed separately:
+#   rustup    → curl https://sh.rustup.rs
+#   nvm       → curl https://raw.githubusercontent.com/nvm-sh/nvm/...
+#   uv        → curl https://astral.sh/uv/install.sh
+#   oh-my-zsh → sh -c "$(curl ...ohmyz.sh/install.sh)"
+#   p10k      → git clone into $ZSH_CUSTOM/themes/
+# ──────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Cross-platform shell configuration files for bash (Windows/Git Bash) and zsh (macOS/Linux).
 
+## Automated Installation
+
+Install all tools with one command:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/iancleary/dotfiles/main/install.sh | bash
+```
+
+Or clone first:
+
+```bash
+git clone https://github.com/iancleary/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+./install.sh
+```
+
+Options: `--dry-run`, `--minimal`, `--skip-rust`, `--skip-node`
+
 ## Overview
 
 This repository manages dotfiles for multiple operating systems with a sync utility that handles bidirectional synchronization between your home directory and this repository.

--- a/Scoopfile.json
+++ b/Scoopfile.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
+  "_comment": "Windows package list — Usage: scoop import Scoopfile.json",
+  "buckets": [
+    { "Name": "main" },
+    { "Name": "extras" }
+  ],
+  "apps": [
+    { "Name": "eza",      "Source": "main" },
+    { "Name": "bat",      "Source": "main" },
+    { "Name": "delta",    "Source": "main" },
+    { "Name": "zoxide",   "Source": "main" },
+    { "Name": "just",     "Source": "main" },
+    { "Name": "ripgrep",  "Source": "main" },
+    { "Name": "lazygit",  "Source": "extras" },
+    { "Name": "gum",      "Source": "main" },
+    { "Name": "fd",       "Source": "main" },
+    { "Name": "jq",       "Source": "main" },
+    { "Name": "gh",       "Source": "main" },
+    { "Name": "neovim",   "Source": "main" },
+    { "Name": "shellcheck", "Source": "main" }
+  ]
+}

--- a/Scoopfile.json
+++ b/Scoopfile.json
@@ -6,18 +6,9 @@
     { "Name": "extras" }
   ],
   "apps": [
-    { "Name": "eza",      "Source": "main" },
-    { "Name": "bat",      "Source": "main" },
-    { "Name": "delta",    "Source": "main" },
-    { "Name": "zoxide",   "Source": "main" },
-    { "Name": "just",     "Source": "main" },
-    { "Name": "ripgrep",  "Source": "main" },
-    { "Name": "lazygit",  "Source": "extras" },
-    { "Name": "gum",      "Source": "main" },
-    { "Name": "fd",       "Source": "main" },
-    { "Name": "jq",       "Source": "main" },
-    { "Name": "gh",       "Source": "main" },
-    { "Name": "neovim",   "Source": "main" },
+    { "Name": "jq",         "Source": "main" },
+    { "Name": "gh",         "Source": "main" },
+    { "Name": "neovim",     "Source": "main" },
     { "Name": "shellcheck", "Source": "main" }
   ]
 }

--- a/cargo-tools.txt
+++ b/cargo-tools.txt
@@ -1,0 +1,18 @@
+# Cargo tools — installed via: cargo install <name>
+# One tool per line. Comments and blank lines ignored.
+
+# CLI replacements
+bat
+eza
+git-delta
+ripgrep
+fd-find
+zoxide
+just
+
+# Dev tools
+cargo-watch
+cargo-mutants
+cargo-semver-checks
+cargo-nextest
+cargo-edit

--- a/docs/installer-trade-study.md
+++ b/docs/installer-trade-study.md
@@ -15,7 +15,8 @@ install.sh
 ├── detect OS / arch
 ├── install package manager (brew / scoop)
 ├── install tools via package manager
-├── install Rust via rustup.rs
+├── install Rust via rustup.rs + cargo install --locked
+├── install Go via go.dev tarball/brew + go install
 ├── install Node via nvm
 ├── install uv via astral.sh
 └── summary

--- a/docs/installer-trade-study.md
+++ b/docs/installer-trade-study.md
@@ -1,0 +1,274 @@
+# Installer Trade Study — Cross-Platform Tool Installation
+
+## Goal
+
+One-command setup of all development tools on a fresh macOS or Windows machine, inspired by the Determinate Systems `curl | sh` pattern.
+
+## Strategies Evaluated
+
+### Option A: Single Bash Script (`install.sh`)
+
+**Pattern**: `curl -fsSL https://raw.githubusercontent.com/.../install.sh | bash`
+
+```
+install.sh
+├── detect OS / arch
+├── install package manager (brew / scoop)
+├── install tools via package manager
+├── install Rust via rustup.rs
+├── install Node via nvm
+├── install uv via astral.sh
+└── summary
+```
+
+**Pros**:
+- Dead simple — one file, no dependencies beyond bash
+- Works immediately from curl pipe (Determinate Systems pattern)
+- Easy to read and modify
+- Can run `--dry-run` to preview
+- Works on macOS and Windows/Git Bash
+
+**Cons**:
+- Bash scripting is fragile — error handling is manual
+- No parallelism (installs are sequential)
+- Hard to test (need actual machines or containers)
+- Windows support via Git Bash is janky (Scoop needs PowerShell)
+- No lockfile or version pinning — `brew install eza` gets whatever's latest
+
+**Complexity**: Low
+**Maintenance**: Low
+**Best for**: Personal use, quick setup
+
+---
+
+### Option B: Brewfile + Scoopfile (Declarative Package Lists)
+
+**Pattern**: Separate declarative package lists per platform, thin wrapper script.
+
+```
+Brewfile              # macOS: brew bundle
+Scoopfile.json        # Windows: scoop import
+install.sh            # thin wrapper: detect OS, run the right one
+install-extras.sh     # Rust, Node, uv (not in package managers)
+```
+
+**macOS Brewfile** (native Homebrew feature):
+```ruby
+# Core CLI
+brew "eza"
+brew "bat"
+brew "git-delta"
+brew "zoxide"
+brew "just"
+brew "ripgrep"
+brew "lazygit"
+brew "gum"
+brew "fd"
+brew "jq"
+brew "gh"
+brew "neovim"
+
+# Casks
+cask "ghostty"
+```
+
+**Windows Scoopfile.json**:
+```json
+{
+  "buckets": [{"Name": "main"}, {"Name": "extras"}],
+  "apps": [
+    {"Name": "eza"}, {"Name": "bat"}, {"Name": "delta"},
+    {"Name": "zoxide"}, {"Name": "just"}, {"Name": "ripgrep"},
+    {"Name": "lazygit"}, {"Name": "gum"}, {"Name": "fd"},
+    {"Name": "jq"}, {"Name": "gh"}
+  ]
+}
+```
+
+**Pros**:
+- Declarative — add/remove tools by editing a list, not script logic
+- `brew bundle` is idempotent, well-tested, handles dependencies
+- Brewfile can include casks (GUI apps like Ghostty)
+- Easy to diff — "what changed in my tool list?" is a clean git diff
+- Community-standard pattern (many dotfiles repos use Brewfile)
+
+**Cons**:
+- Two separate files to maintain (Brewfile + Scoopfile)
+- Doesn't cover non-package-manager tools (Rust, nvm, uv) — needs a companion script
+- `brew bundle` is macOS only; Scoop import is less mature
+- No cross-platform single source of truth
+
+**Complexity**: Low–Medium
+**Maintenance**: Low (declarative lists are easy to update)
+**Best for**: Separation of concerns, adding GUI apps too
+
+---
+
+### Option C: YAML/TOML Manifest + Rust/Python Runner
+
+**Pattern**: Single manifest file defining all tools, cross-platform runner interprets it.
+
+```
+tools.yaml            # single source of truth
+install.py            # or install (Rust binary)
+```
+
+**tools.yaml**:
+```yaml
+tools:
+  core:
+    - name: eza
+      macos: { brew: eza }
+      windows: { scoop: eza }
+      check: "eza --version"
+    - name: bat
+      macos: { brew: bat }
+      windows: { scoop: bat }
+      check: "bat --version"
+    - name: delta
+      macos: { brew: git-delta }
+      windows: { scoop: delta }
+      check: "delta --version"
+    # ...
+  
+  languages:
+    - name: rust
+      install: "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+      check: "rustc --version"
+    - name: node
+      install_macos: "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash"
+      install_windows: "scoop install nvm"
+      check: "node --version"
+
+  cargo:
+    - name: cargo-watch
+      install: "cargo install cargo-watch"
+      check: "cargo watch --version"
+```
+
+**Pros**:
+- Single source of truth across platforms
+- Adding a tool = adding 3 lines to YAML
+- Can generate Brewfile/Scoopfile from the manifest
+- Version pinning possible
+- Runner can parallelize installs, show progress bars, handle retries
+
+**Cons**:
+- Needs Python or Rust pre-installed to run the installer (chicken-and-egg)
+- Over-engineered for ~20 tools
+- More code to maintain (the runner is non-trivial)
+- YAML parsing in bash is painful; needs a real language
+
+**Complexity**: Medium–High
+**Maintenance**: Medium
+**Best for**: Teams, 50+ tools, CI/CD pipelines
+
+---
+
+### Option D: Nix / Home Manager (Fully Declarative)
+
+**Pattern**: Nix flake with home-manager for user-level packages.
+
+```nix
+# flake.nix
+{
+  inputs = { nixpkgs.url = "github:nixpkgs/nixpkgs/nixos-unstable"; home-manager.url = "..."; };
+  outputs = { ... }: {
+    homeConfigurations."iancleary" = home-manager.lib.homeManagerConfiguration {
+      packages = with pkgs; [ eza bat delta zoxide just ripgrep lazygit gum fd jq gh neovim ];
+    };
+  };
+}
+```
+
+**Pros**:
+- Truly reproducible — same versions everywhere
+- Single command: `nix run . -- switch`
+- Rollback support
+- Massive package repository (90,000+ packages)
+- Cross-platform (macOS via nix-darwin, Linux native)
+
+**Cons**:
+- Nix learning curve is steep
+- Nix doesn't support Windows (only WSL)
+- Large disk footprint (~5 GB for Nix store)
+- Shell integration (oh-my-zsh, p10k) is awkward in Nix
+- Conflicts with Homebrew if both are installed
+- Overkill for dotfiles
+
+**Complexity**: High
+**Maintenance**: Medium (once set up, very stable)
+**Best for**: Linux-first, reproducibility-obsessed, NixOS users
+
+---
+
+### Option E: Ansible Playbook
+
+**Pattern**: Ansible playbook with roles per tool category.
+
+```yaml
+# playbook.yml
+- hosts: localhost
+  roles:
+    - role: package-manager  # install brew/scoop
+    - role: cli-tools        # eza, bat, delta, etc.
+    - role: languages        # rust, node, python
+    - role: shell            # oh-my-zsh, p10k
+```
+
+**Pros**:
+- Mature, well-documented tool
+- Idempotent by design
+- Good cross-platform support
+- Can configure OS settings too (macOS defaults, etc.)
+- Roles are reusable and composable
+
+**Cons**:
+- Requires Python + Ansible pre-installed
+- Verbose YAML for simple `brew install` commands
+- Slow startup (Python + Ansible overhead)
+- Overkill for personal dotfiles
+- Windows support is limited
+
+**Complexity**: Medium
+**Maintenance**: Medium
+**Best for**: Infrastructure-as-code teams, managing multiple machines
+
+---
+
+## Comparison Matrix
+
+| Criteria | A: Bash | B: Brewfile | C: YAML+Runner | D: Nix | E: Ansible |
+|----------|---------|-------------|-----------------|--------|------------|
+| Simplicity | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐ | ⭐⭐ |
+| Windows support | ⭐⭐ | ⭐⭐ | ⭐⭐⭐ | ❌ | ⭐ |
+| macOS support | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ |
+| Curl-pipe install | ✅ | ✅ (wrapper) | ❌ | ✅ | ❌ |
+| Declarative | ❌ | ✅ | ✅ | ✅ | ✅ |
+| No dependencies | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Version pinning | ❌ | ❌ | ✅ | ✅ | ❌ |
+| GUI apps (casks) | ❌ | ✅ | ✅ | ⭐⭐ | ✅ |
+| Maintenance effort | Low | Low | Medium | Medium | Medium |
+| Time to implement | 2hr | 1hr | 4hr | 8hr | 4hr |
+
+## Recommendation
+
+**Implement Option A + B hybrid:**
+
+1. **`Brewfile`** for macOS packages (declarative, `brew bundle` handles everything)
+2. **`Scoopfile.json`** for Windows packages
+3. **`install.sh`** thin wrapper that:
+   - Detects OS
+   - Installs Homebrew/Scoop if needed
+   - Runs `brew bundle` or `scoop import`
+   - Installs non-package-manager tools (Rust, nvm, uv)
+   - Shows summary
+4. **`install-cargo-tools.sh`** separate for cargo installs (slow, optional)
+
+This gives you:
+- The `curl | sh` simplicity of Option A
+- The declarative tool lists of Option B
+- No exotic dependencies (no Python, Nix, or Ansible required)
+- Easy to maintain — adding a tool = one line in Brewfile
+
+The sub-agent is currently building Option A (pure bash). I'd suggest we also add the Brewfile/Scoopfile alongside it so you have both patterns to compare.

--- a/go-tools.txt
+++ b/go-tools.txt
@@ -1,0 +1,5 @@
+# Go tools — installed via: go install <module>@latest
+# One tool per line. Comments and blank lines ignored.
+
+github.com/charmbracelet/gum@latest
+github.com/jesseduffield/lazygit@latest

--- a/install-cargo-tools.sh
+++ b/install-cargo-tools.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# install-cargo-tools.sh — Install cargo-based development tools
+#
+# These are separated from install.sh because they compile from source
+# and can take several minutes.
+#
+# Usage:
+#   ./install-cargo-tools.sh
+#   ./install-cargo-tools.sh --dry-run
+
+set -euo pipefail
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+if ! command -v cargo &>/dev/null; then
+  echo -e "${RED}Error:${RESET} cargo not found. Run install.sh first to install Rust."
+  exit 1
+fi
+
+TOOLS=(
+  "cargo-watch"
+  "cargo-mutants"
+  "cargo-semver-checks"
+  "cargo-edit"
+)
+
+echo -e "\n${BOLD}Installing cargo tools${RESET} ${DIM}(this may take a few minutes)${RESET}\n"
+
+installed=0
+present=0
+failed=0
+
+for tool in "${TOOLS[@]}"; do
+  bin="${tool}"
+  if cargo install --list 2>/dev/null | grep -q "^${tool} "; then
+    echo -e "  ${GREEN}✓${RESET} ${tool} (already installed)"
+    (( present++ )) || true
+  else
+    echo -ne "  ${BLUE}→${RESET} installing ${BOLD}${tool}${RESET}..."
+    if $DRY_RUN; then
+      echo -e " ${DIM}(dry-run)${RESET}"
+      (( installed++ )) || true
+    elif cargo install "$tool" 2>/dev/null; then
+      echo -e "done"
+      (( installed++ )) || true
+    else
+      echo -e "${RED}failed${RESET}"
+      (( failed++ )) || true
+    fi
+  fi
+done
+
+echo -e "\n${BOLD}Summary:${RESET} ${GREEN}${installed} installed${RESET}, ${BLUE}${present} present${RESET}, ${RED}${failed} failed${RESET}\n"

--- a/install.sh
+++ b/install.sh
@@ -250,8 +250,32 @@ install_rust() {
   if has rustc; then
     record_present "Rust $(rustc --version 2>/dev/null | awk '{print $2}')"
   else
-    log_install "Rust (via rustup)"
-    run_or_dry bash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y" && record_installed || record_failed "rustup" "install failed"
+    case "$OS" in
+      macos|linux)
+        log_install "Rust (via rustup)"
+        run_or_dry bash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y" && record_installed || record_failed "rustup" "install failed"
+        ;;
+      windows)
+        # Windows requires Visual Studio C++ Build Tools for the MSVC linker.
+        # rustup-init.exe is the official Windows installer (not the curl | sh script).
+        if ! has cl && ! has link; then
+          echo -e "  ${YELLOW}⚠${RESET}  Visual Studio C++ Build Tools not detected."
+          echo -e "  ${DIM}  Install from: https://visualstudio.microsoft.com/visual-cpp-build-tools/${RESET}"
+          echo -e "  ${DIM}  Select 'Desktop development with C++' workload.${RESET}"
+          echo -e "  ${DIM}  Alternatively, use rustup's GNU toolchain: rustup default stable-x86_64-pc-windows-gnu${RESET}"
+        fi
+        log_install "Rust (via rustup-init.exe)"
+        if $DRY_RUN; then
+          echo -e " ${DIM}(dry-run)${RESET}"
+          (( COUNT_SKIPPED++ )) || true
+        else
+          local tmpdir
+          tmpdir="$(mktemp -d)"
+          curl -fsSL "https://win.rustup.rs/x86_64" -o "$tmpdir/rustup-init.exe"
+          "$tmpdir/rustup-init.exe" -y --default-toolchain stable 2>/dev/null && record_installed || record_failed "rustup" "rustup-init.exe failed"
+        fi
+        ;;
+    esac
     # Source cargo env for this session
     [[ -f "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
   fi

--- a/install.sh
+++ b/install.sh
@@ -399,22 +399,54 @@ install_node() {
 
   if has node; then
     record_present "Node.js $(node --version 2>/dev/null)"
-  else
-    # Install nvm first
-    if [[ ! -d "$HOME/.nvm" ]]; then
-      log_install "nvm"
-      run_or_dry bash -c 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash' && record_installed || record_failed "nvm" "install failed"
-    else
-      record_present "nvm"
-    fi
-
-    # Install latest LTS
-    if ! $DRY_RUN && [[ -s "$HOME/.nvm/nvm.sh" ]]; then
-      source "$HOME/.nvm/nvm.sh"
-      log_install "Node.js LTS"
-      nvm install --lts &>/dev/null && record_installed || record_failed "Node.js" "nvm install failed"
-    fi
+    return
   fi
+
+  case "$OS" in
+    macos|linux)
+      # nvm-sh: https://github.com/nvm-sh/nvm
+      if [[ ! -d "$HOME/.nvm" ]]; then
+        log_install "nvm"
+        run_or_dry bash -c 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash' && record_installed || record_failed "nvm" "install failed"
+      else
+        record_present "nvm"
+      fi
+
+      # Install latest LTS
+      if ! $DRY_RUN && [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+        source "$HOME/.nvm/nvm.sh"
+        log_install "Node.js LTS"
+        nvm install --lts &>/dev/null && record_installed || record_failed "Node.js" "nvm install failed"
+      fi
+      ;;
+    windows)
+      # nvm-windows: https://github.com/coreybutler/nvm-windows
+      if has nvm; then
+        record_present "nvm-windows"
+      else
+        log_install "nvm-windows"
+        if $DRY_RUN; then
+          echo -e " ${DIM}(dry-run)${RESET}"
+          (( COUNT_SKIPPED++ )) || true
+        else
+          local tmpdir
+          tmpdir="$(mktemp -d)"
+          local nvm_win_version="1.2.2"
+          curl -fsSL "https://github.com/coreybutler/nvm-windows/releases/download/${nvm_win_version}/nvm-noinstall.zip" -o "$tmpdir/nvm.zip"
+          mkdir -p "$HOME/AppData/Roaming/nvm"
+          unzip -qo "$tmpdir/nvm.zip" -d "$HOME/AppData/Roaming/nvm" && record_installed || record_failed "nvm-windows" "install failed"
+          echo -e "  ${YELLOW}⚠${RESET}  Add to PATH: ${DIM}%APPDATA%\\nvm${RESET} and ${DIM}%APPDATA%\\nvm\\nodejs${RESET}"
+          echo -e "  ${DIM}  Or use the full installer: https://github.com/coreybutler/nvm-windows/releases${RESET}"
+        fi
+      fi
+
+      # Install latest LTS
+      if ! $DRY_RUN && has nvm; then
+        log_install "Node.js LTS"
+        nvm install lts &>/dev/null && nvm use lts &>/dev/null && record_installed || record_failed "Node.js" "nvm install failed"
+      fi
+      ;;
+  esac
 }
 
 # ─── Phase 6: Python (uv) ─────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# install.sh — Cross-platform tool installer for iancleary/dotfiles
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/iancleary/dotfiles/main/install.sh | bash
+#
+#   Or clone and run:
+#   ./install.sh
+#
+# Options:
+#   --dry-run    Show what would be installed without installing
+#   --minimal    Install only core CLI tools (skip dev tools)
+#   --skip-rust  Skip Rust toolchain installation
+#   --skip-node  Skip Node.js/nvm installation
+
+set -euo pipefail
+
+# ─── Options ───────────────────────────────────────────────────────────────────
+
+DRY_RUN=false
+MINIMAL=false
+SKIP_RUST=false
+SKIP_NODE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)    DRY_RUN=true ;;
+    --minimal)    MINIMAL=true ;;
+    --skip-rust)  SKIP_RUST=true ;;
+    --skip-node)  SKIP_NODE=true ;;
+    --help|-h)
+      sed -n '2,/^$/p' "$0" 2>/dev/null | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown option: $arg"; exit 1 ;;
+  esac
+done
+
+# ─── Colors & Output ──────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+COUNT_INSTALLED=0
+COUNT_PRESENT=0
+COUNT_SKIPPED=0
+COUNT_FAILED=0
+
+log_ok()      { echo -e "  ${GREEN}✓${RESET} $1"; }
+log_skip()    { echo -e "  ${YELLOW}–${RESET} $1 ${DIM}(skipped)${RESET}"; }
+log_install() { echo -ne "  ${BLUE}→${RESET} installing ${BOLD}$1${RESET}..."; }
+log_done()    { echo -e "done"; }
+log_fail()    { echo -e "${RED}failed${RESET}"; }
+log_section() { echo -e "\n${BOLD}$1${RESET}\n"; }
+
+record_present() { log_ok "$1"; (( COUNT_PRESENT++ )) || true; }
+record_installed() { (( COUNT_INSTALLED++ )) || true; }
+record_skipped() { log_skip "$1"; (( COUNT_SKIPPED++ )) || true; }
+record_failed() { log_fail; echo -e "  ${RED}✗${RESET} $1 — $2"; (( COUNT_FAILED++ )) || true; }
+
+# ─── Platform Detection ───────────────────────────────────────────────────────
+
+detect_platform() {
+  OS="unknown"
+  ARCH="$(uname -m)"
+
+  case "$(uname -s)" in
+    Darwin)  OS="macos" ;;
+    Linux)   OS="linux" ;;
+    MINGW*|MSYS*|CYGWIN*) OS="windows" ;;
+  esac
+
+  # Normalize arch
+  case "$ARCH" in
+    aarch64|arm64) ARCH="arm64" ;;
+    x86_64|amd64)  ARCH="x86_64" ;;
+  esac
+}
+
+# ─── Connectivity Check ───────────────────────────────────────────────────────
+
+check_internet() {
+  if ! curl -fsSL --connect-timeout 5 https://github.com > /dev/null 2>&1; then
+    echo -e "${RED}Error:${RESET} No internet connectivity detected."
+    echo "This installer requires internet access to download tools."
+    exit 1
+  fi
+}
+
+# ─── Helpers ───────────────────────────────────────────────────────────────────
+
+has() { command -v "$1" &>/dev/null; }
+
+version_of() {
+  local v
+  v=$("$1" --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+[0-9.]*' | head -1)
+  echo "${v:-unknown}"
+}
+
+run_or_dry() {
+  if $DRY_RUN; then
+    echo -e " ${DIM}(dry-run)${RESET}"
+    record_installed
+  else
+    if eval "$@" > /dev/null 2>&1; then
+      log_done
+      record_installed
+    else
+      record_failed "$1" "installation command failed"
+    fi
+  fi
+}
+
+# ─── Package Manager Installation ─────────────────────────────────────────────
+
+install_homebrew() {
+  if has brew; then
+    record_present "Homebrew ($(version_of brew))"
+    return
+  fi
+  log_install "Homebrew"
+  run_or_dry '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+}
+
+install_scoop() {
+  if has scoop; then
+    record_present "Scoop"
+    return
+  fi
+  log_install "Scoop"
+  run_or_dry 'powershell.exe -NoProfile -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; irm get.scoop.sh | iex"'
+}
+
+# ─── Brew/Scoop Tool Install ──────────────────────────────────────────────────
+
+install_brew_tool() {
+  local cmd="$1" pkg="${2:-$1}"
+  if has "$cmd"; then
+    record_present "$cmd ($(version_of "$cmd"))"
+    return
+  fi
+  log_install "$cmd"
+  run_or_dry "brew install $pkg"
+}
+
+install_scoop_tool() {
+  local cmd="$1" pkg="${2:-$1}"
+  if has "$cmd"; then
+    record_present "$cmd ($(version_of "$cmd"))"
+    return
+  fi
+  log_install "$cmd"
+  run_or_dry "scoop install $pkg"
+}
+
+install_cli_tool() {
+  local cmd="$1" pkg="${2:-$1}"
+  if [[ "$OS" == "macos" || "$OS" == "linux" ]]; then
+    install_brew_tool "$cmd" "$pkg"
+  elif [[ "$OS" == "windows" ]]; then
+    install_scoop_tool "$cmd" "$pkg"
+  fi
+}
+
+# ─── Rust ──────────────────────────────────────────────────────────────────────
+
+install_rust() {
+  if $SKIP_RUST; then
+    record_skipped "Rust toolchain"
+    return
+  fi
+  if has rustup; then
+    record_present "Rust ($(rustc --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo 'installed'))"
+    return
+  fi
+  log_install "Rust (via rustup)"
+  run_or_dry 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path'
+}
+
+# ─── Node.js / nvm ────────────────────────────────────────────────────────────
+
+install_node() {
+  if $SKIP_NODE; then
+    record_skipped "Node.js/nvm"
+    return
+  fi
+
+  local nvm_dir="${NVM_DIR:-$HOME/.nvm}"
+
+  if [[ "$OS" == "windows" ]]; then
+    if has nvm; then
+      record_present "nvm-windows ($(nvm --version 2>/dev/null || echo 'installed'))"
+    else
+      log_install "nvm-windows"
+      echo -e " ${YELLOW}manual install required${RESET}"
+      echo -e "  ${DIM}Download from: https://github.com/coreybutler/nvm-windows/releases${RESET}"
+      record_skipped "nvm-windows (manual install)"
+    fi
+    return
+  fi
+
+  if [[ -s "$nvm_dir/nvm.sh" ]]; then
+    record_present "nvm ($(. "$nvm_dir/nvm.sh" && nvm --version 2>/dev/null || echo 'installed'))"
+  else
+    log_install "nvm"
+    run_or_dry 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash'
+  fi
+
+  # Install LTS if nvm is available
+  if [[ -s "$nvm_dir/nvm.sh" ]] && ! $DRY_RUN; then
+    # shellcheck disable=SC1091
+    . "$nvm_dir/nvm.sh"
+    if has node; then
+      record_present "Node.js ($(node --version 2>/dev/null))"
+    else
+      log_install "Node.js LTS"
+      run_or_dry 'nvm install --lts'
+    fi
+  fi
+}
+
+# ─── uv (Python) ──────────────────────────────────────────────────────────────
+
+install_uv() {
+  if has uv; then
+    record_present "uv ($(version_of uv))"
+    return
+  fi
+  log_install "uv"
+  run_or_dry 'curl -LsSf https://astral.sh/uv/install.sh | sh'
+}
+
+# ─── Shell Enhancements ───────────────────────────────────────────────────────
+
+install_shell_enhancements() {
+  if [[ "$OS" == "macos" || "$OS" == "linux" ]]; then
+    # oh-my-zsh
+    if [[ -d "${ZSH:-$HOME/.oh-my-zsh}" ]]; then
+      record_present "oh-my-zsh"
+    else
+      log_install "oh-my-zsh"
+      run_or_dry 'sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended'
+    fi
+
+    # Powerlevel10k
+    local p10k_dir="${ZSH_CUSTOM:-${ZSH:-$HOME/.oh-my-zsh}/custom}/themes/powerlevel10k"
+    if [[ -d "$p10k_dir" ]]; then
+      record_present "Powerlevel10k"
+    else
+      log_install "Powerlevel10k"
+      run_or_dry "git clone --depth=1 https://github.com/romkatv/powerlevel10k.git '$p10k_dir'"
+    fi
+
+  elif [[ "$OS" == "windows" ]]; then
+    if [[ -d "${OSH:-$HOME/.oh-my-bash}" ]]; then
+      record_present "oh-my-bash"
+    else
+      log_install "oh-my-bash"
+      run_or_dry 'bash -c "$(curl -fsSL https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh)" --unattended'
+    fi
+  fi
+}
+
+# ─── Main ──────────────────────────────────────────────────────────────────────
+
+main() {
+  detect_platform
+
+  echo ""
+  echo -e "${BOLD}╔══════════════════════════════════════════════╗${RESET}"
+  echo -e "${BOLD}║     iancleary/dotfiles — Tool Installer      ║${RESET}"
+  echo -e "${BOLD}╚══════════════════════════════════════════════╝${RESET}"
+  echo ""
+
+  if $DRY_RUN; then
+    echo -e "  ${YELLOW}DRY RUN${RESET} — no changes will be made"
+    echo ""
+  fi
+
+  echo -e "  Detected: ${BOLD}${OS}${RESET} (${ARCH})"
+
+  if [[ "$OS" == "unknown" ]]; then
+    echo -e "  ${RED}Unsupported operating system${RESET}"
+    exit 1
+  fi
+
+  check_internet
+  echo -e "  Internet: ${GREEN}connected${RESET}"
+
+  # ── Package Manager ──
+  log_section "Package Manager"
+
+  if [[ "$OS" == "macos" || "$OS" == "linux" ]]; then
+    install_homebrew
+  elif [[ "$OS" == "windows" ]]; then
+    install_scoop
+  fi
+
+  # ── Core CLI Tools ──
+  log_section "Core CLI Tools"
+
+  install_cli_tool eza
+  install_cli_tool bat
+  install_cli_tool delta git-delta
+  install_cli_tool zoxide
+  install_cli_tool just
+  install_cli_tool rg ripgrep
+  install_cli_tool lazygit
+  install_cli_tool gum
+  install_cli_tool fd
+  install_cli_tool jq
+
+  if ! $MINIMAL; then
+    # ── Development Tools ──
+    log_section "Development Tools"
+
+    install_cli_tool gh
+    install_rust
+    install_node
+    install_uv
+
+    # ── macOS-only Tools ──
+    if [[ "$OS" == "macos" ]]; then
+      log_section "macOS Tools"
+      install_brew_tool nvim neovim
+      if has ghostty; then
+        record_present "Ghostty"
+      else
+        echo -e "  ${DIM}ℹ Ghostty — install manually from https://ghostty.org${RESET}"
+      fi
+    fi
+
+    # ── Shell Enhancements ──
+    log_section "Shell Enhancements"
+    install_shell_enhancements
+  else
+    record_skipped "Development tools (--minimal)"
+    record_skipped "Shell enhancements (--minimal)"
+  fi
+
+  # ── Summary ──
+  echo ""
+  echo -e "${BOLD}───────────────────────────────────────────────${RESET}"
+  echo -e "${BOLD}Summary${RESET}"
+  echo -e "  Installed:       ${GREEN}${COUNT_INSTALLED}${RESET}"
+  echo -e "  Already present: ${BLUE}${COUNT_PRESENT}${RESET}"
+  echo -e "  Skipped:         ${YELLOW}${COUNT_SKIPPED}${RESET}"
+  echo -e "  Failed:          ${RED}${COUNT_FAILED}${RESET}"
+  echo ""
+
+  if (( COUNT_FAILED > 0 )); then
+    echo -e "  ${RED}Some installations failed. Review the output above.${RESET}"
+    echo ""
+  fi
+
+  echo -e "${BOLD}Next steps:${RESET}"
+  echo -e "  1. Run ${BOLD}./sync-dotfiles.sh push${RESET}   to restore your dotfiles"
+  echo -e "  2. Restart your shell             to pick up new tools"
+  echo -e "  3. Run ${BOLD}just status${RESET}                to verify everything"
+  if ! $MINIMAL && $SKIP_RUST; then
+    :
+  elif ! $MINIMAL; then
+    echo -e "  4. Run ${BOLD}./install-cargo-tools.sh${RESET}  to install cargo extras (optional)"
+  fi
+  echo ""
+}
+
+main

--- a/install.sh
+++ b/install.sh
@@ -9,25 +9,25 @@
 #
 # Options:
 #   --dry-run    Show what would be installed without installing
-#   --minimal    Install only core CLI tools (skip dev tools)
-#   --skip-rust  Skip Rust toolchain installation
+#   --skip-rust  Skip Rust toolchain + cargo tools
 #   --skip-node  Skip Node.js/nvm installation
+#   --skip-sync  Skip dotfiles clone and sync
 
 set -euo pipefail
 
 # ─── Options ───────────────────────────────────────────────────────────────────
 
 DRY_RUN=false
-MINIMAL=false
 SKIP_RUST=false
 SKIP_NODE=false
+SKIP_SYNC=false
 
 for arg in "$@"; do
   case "$arg" in
     --dry-run)    DRY_RUN=true ;;
-    --minimal)    MINIMAL=true ;;
     --skip-rust)  SKIP_RUST=true ;;
     --skip-node)  SKIP_NODE=true ;;
+    --skip-sync)  SKIP_SYNC=true ;;
     --help|-h)
       sed -n '2,/^$/p' "$0" 2>/dev/null | sed 's/^# \?//'
       exit 0
@@ -58,10 +58,18 @@ log_done()    { echo -e "done"; }
 log_fail()    { echo -e "${RED}failed${RESET}"; }
 log_section() { echo -e "\n${BOLD}$1${RESET}\n"; }
 
-record_present() { log_ok "$1"; (( COUNT_PRESENT++ )) || true; }
-record_installed() { (( COUNT_INSTALLED++ )) || true; }
-record_skipped() { log_skip "$1"; (( COUNT_SKIPPED++ )) || true; }
-record_failed() { log_fail; echo -e "  ${RED}✗${RESET} $1 — $2"; (( COUNT_FAILED++ )) || true; }
+record_present()   { log_ok "$1 ${DIM}(already installed)${RESET}"; (( COUNT_PRESENT++ )) || true; }
+record_installed() { log_done; (( COUNT_INSTALLED++ )) || true; }
+record_skipped()   { log_skip "$1"; (( COUNT_SKIPPED++ )) || true; }
+record_failed()    { log_fail; echo -e "  ${RED}✗${RESET} $1 — $2"; (( COUNT_FAILED++ )) || true; }
+
+run_or_dry() {
+  if $DRY_RUN; then
+    echo -e "  ${DIM}(dry-run) would run: $*${RESET}"
+    return 0
+  fi
+  "$@"
+}
 
 # ─── Platform Detection ───────────────────────────────────────────────────────
 
@@ -70,304 +78,381 @@ detect_platform() {
   ARCH="$(uname -m)"
 
   case "$(uname -s)" in
-    Darwin)  OS="macos" ;;
-    Linux)   OS="linux" ;;
+    Darwin)               OS="macos" ;;
+    Linux)                OS="linux" ;;
     MINGW*|MSYS*|CYGWIN*) OS="windows" ;;
   esac
 
-  # Normalize arch
   case "$ARCH" in
-    aarch64|arm64) ARCH="arm64" ;;
-    x86_64|amd64)  ARCH="x86_64" ;;
+    x86_64|amd64) ARCH="x86_64" ;;
+    arm64|aarch64) ARCH="arm64" ;;
   esac
 }
 
-# ─── Connectivity Check ───────────────────────────────────────────────────────
-
-check_internet() {
-  if ! curl -fsSL --connect-timeout 5 https://github.com > /dev/null 2>&1; then
-    echo -e "${RED}Error:${RESET} No internet connectivity detected."
-    echo "This installer requires internet access to download tools."
-    exit 1
-  fi
-}
-
-# ─── Helpers ───────────────────────────────────────────────────────────────────
+# ─── Helpers ──────────────────────────────────────────────────────────────────
 
 has() { command -v "$1" &>/dev/null; }
 
-version_of() {
-  local v
-  v=$("$1" --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+[0-9.]*' | head -1)
-  echo "${v:-unknown}"
-}
+# Install a single tool via the platform package manager
+pkg_install() {
+  local name="$1"
+  local cmd="${2:-$1}"  # command to check (defaults to package name)
 
-run_or_dry() {
+  if has "$cmd"; then
+    record_present "$name"
+    return 0
+  fi
+
+  log_install "$name"
   if $DRY_RUN; then
     echo -e " ${DIM}(dry-run)${RESET}"
-    record_installed
+    (( COUNT_SKIPPED++ )) || true
+    return 0
+  fi
+
+  case "$OS" in
+    macos)   brew install "$name" &>/dev/null && record_installed || record_failed "$name" "brew install failed" ;;
+    linux)   sudo apt-get install -y "$name" &>/dev/null && record_installed || record_failed "$name" "apt install failed" ;;
+    windows) scoop install "$name" &>/dev/null && record_installed || record_failed "$name" "scoop install failed" ;;
+  esac
+}
+
+# Read a declarative tool list file, skipping comments and blanks
+read_tool_list() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo -e "  ${YELLOW}⚠${RESET} $file not found, skipping"
+    return
+  fi
+  grep -v '^\s*#' "$file" | grep -v '^\s*$'
+}
+
+# ─── Banner ───────────────────────────────────────────────────────────────────
+
+print_banner() {
+  echo ""
+  echo -e "${BLUE}╔══════════════════════════════════════════════════════╗${RESET}"
+  echo -e "${BLUE}║${RESET}     ${BOLD}iancleary/dotfiles — Tool Installer${RESET}              ${BLUE}║${RESET}"
+  echo -e "${BLUE}╚══════════════════════════════════════════════════════╝${RESET}"
+  echo ""
+  echo -e "  Detected: ${BOLD}${OS}${RESET} (${ARCH})"
+  $DRY_RUN && echo -e "  Mode:     ${YELLOW}dry-run${RESET} (no changes will be made)"
+  echo ""
+}
+
+# ─── Phase 1: Package Manager ─────────────────────────────────────────────────
+
+install_package_manager() {
+  log_section "Phase 1: Package Manager"
+
+  case "$OS" in
+    macos)
+      if has brew; then
+        record_present "Homebrew"
+      else
+        log_install "Homebrew"
+        run_or_dry /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" && record_installed || record_failed "Homebrew" "install failed"
+      fi
+      ;;
+    windows)
+      if has scoop; then
+        record_present "Scoop"
+      else
+        log_install "Scoop"
+        run_or_dry powershell -Command "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; iex (irm get.scoop.sh)" && record_installed || record_failed "Scoop" "install failed"
+      fi
+      ;;
+    linux)
+      record_present "apt (system)"
+      ;;
+  esac
+}
+
+# ─── Phase 2: System Tools (Brewfile / Scoopfile) ─────────────────────────────
+
+install_system_tools() {
+  log_section "Phase 2: System Tools (platform package manager)"
+
+  # Resolve paths — if running from curl pipe, download the files
+  local brewfile scoopfile
+  if [[ -f "${SCRIPT_DIR:-}/Brewfile" ]]; then
+    brewfile="${SCRIPT_DIR}/Brewfile"
+    scoopfile="${SCRIPT_DIR}/Scoopfile.json"
   else
-    if eval "$@" > /dev/null 2>&1; then
-      log_done
-      record_installed
-    else
-      record_failed "$1" "installation command failed"
-    fi
+    # Running from curl pipe — download declarative lists to temp
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    curl -fsSL "https://raw.githubusercontent.com/iancleary/dotfiles/main/Brewfile" -o "$tmpdir/Brewfile"
+    curl -fsSL "https://raw.githubusercontent.com/iancleary/dotfiles/main/Scoopfile.json" -o "$tmpdir/Scoopfile.json"
+    curl -fsSL "https://raw.githubusercontent.com/iancleary/dotfiles/main/cargo-tools.txt" -o "$tmpdir/cargo-tools.txt"
+    brewfile="$tmpdir/Brewfile"
+    scoopfile="$tmpdir/Scoopfile.json"
+    CARGO_TOOLS_FILE="$tmpdir/cargo-tools.txt"
   fi
+
+  case "$OS" in
+    macos)
+      echo -e "  ${DIM}Using Brewfile: $brewfile${RESET}"
+      if $DRY_RUN; then
+        echo -e "  ${DIM}(dry-run) would run: brew bundle --file=$brewfile${RESET}"
+        local count
+        count=$(grep -c '^brew ' "$brewfile" 2>/dev/null || echo 0)
+        echo -e "  ${DIM}($count packages in Brewfile)${RESET}"
+      else
+        if brew bundle --file="$brewfile" 2>/dev/null; then
+          local count
+          count=$(grep -c '^brew ' "$brewfile" 2>/dev/null || echo 0)
+          log_ok "Brewfile applied ($count packages)"
+          (( COUNT_INSTALLED += count )) || true
+        else
+          record_failed "brew bundle" "some packages may have failed"
+        fi
+      fi
+      ;;
+    windows)
+      echo -e "  ${DIM}Using Scoopfile: $scoopfile${RESET}"
+      if $DRY_RUN; then
+        echo -e "  ${DIM}(dry-run) would run: scoop import $scoopfile${RESET}"
+      else
+        if scoop import "$scoopfile" &>/dev/null; then
+          log_ok "Scoopfile imported"
+          (( COUNT_INSTALLED++ )) || true
+        else
+          record_failed "scoop import" "some packages may have failed"
+        fi
+      fi
+      ;;
+    linux)
+      # On Linux, install the Brewfile equivalents via apt
+      for tool in jq gh gum lazygit neovim shellcheck; do
+        pkg_install "$tool"
+      done
+      ;;
+  esac
 }
 
-# ─── Package Manager Installation ─────────────────────────────────────────────
-
-install_homebrew() {
-  if has brew; then
-    record_present "Homebrew ($(version_of brew))"
-    return
-  fi
-  log_install "Homebrew"
-  run_or_dry '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
-}
-
-install_scoop() {
-  if has scoop; then
-    record_present "Scoop"
-    return
-  fi
-  log_install "Scoop"
-  run_or_dry 'powershell.exe -NoProfile -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; irm get.scoop.sh | iex"'
-}
-
-# ─── Brew/Scoop Tool Install ──────────────────────────────────────────────────
-
-install_brew_tool() {
-  local cmd="$1" pkg="${2:-$1}"
-  if has "$cmd"; then
-    record_present "$cmd ($(version_of "$cmd"))"
-    return
-  fi
-  log_install "$cmd"
-  run_or_dry "brew install $pkg"
-}
-
-install_scoop_tool() {
-  local cmd="$1" pkg="${2:-$1}"
-  if has "$cmd"; then
-    record_present "$cmd ($(version_of "$cmd"))"
-    return
-  fi
-  log_install "$cmd"
-  run_or_dry "scoop install $pkg"
-}
-
-install_cli_tool() {
-  local cmd="$1" pkg="${2:-$1}"
-  if [[ "$OS" == "macos" || "$OS" == "linux" ]]; then
-    install_brew_tool "$cmd" "$pkg"
-  elif [[ "$OS" == "windows" ]]; then
-    install_scoop_tool "$cmd" "$pkg"
-  fi
-}
-
-# ─── Rust ──────────────────────────────────────────────────────────────────────
+# ─── Phase 3: Rust + Cargo Tools ──────────────────────────────────────────────
 
 install_rust() {
+  log_section "Phase 3: Rust Toolchain + Cargo Tools"
+
   if $SKIP_RUST; then
-    record_skipped "Rust toolchain"
-    return
-  fi
-  if has rustup; then
-    record_present "Rust ($(rustc --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo 'installed'))"
-    return
-  fi
-  log_install "Rust (via rustup)"
-  run_or_dry 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path'
-}
-
-# ─── Node.js / nvm ────────────────────────────────────────────────────────────
-
-install_node() {
-  if $SKIP_NODE; then
-    record_skipped "Node.js/nvm"
+    record_skipped "Rust (--skip-rust)"
     return
   fi
 
-  local nvm_dir="${NVM_DIR:-$HOME/.nvm}"
-
-  if [[ "$OS" == "windows" ]]; then
-    if has nvm; then
-      record_present "nvm-windows ($(nvm --version 2>/dev/null || echo 'installed'))"
-    else
-      log_install "nvm-windows"
-      echo -e " ${YELLOW}manual install required${RESET}"
-      echo -e "  ${DIM}Download from: https://github.com/coreybutler/nvm-windows/releases${RESET}"
-      record_skipped "nvm-windows (manual install)"
-    fi
-    return
-  fi
-
-  if [[ -s "$nvm_dir/nvm.sh" ]]; then
-    record_present "nvm ($(. "$nvm_dir/nvm.sh" && nvm --version 2>/dev/null || echo 'installed'))"
+  # rustup
+  if has rustc; then
+    record_present "Rust $(rustc --version 2>/dev/null | awk '{print $2}')"
   else
-    log_install "nvm"
-    run_or_dry 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash'
+    log_install "Rust (via rustup)"
+    run_or_dry bash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y" && record_installed || record_failed "rustup" "install failed"
+    # Source cargo env for this session
+    [[ -f "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
   fi
 
-  # Install LTS if nvm is available
-  if [[ -s "$nvm_dir/nvm.sh" ]] && ! $DRY_RUN; then
-    # shellcheck disable=SC1091
-    . "$nvm_dir/nvm.sh"
-    if has node; then
-      record_present "Node.js ($(node --version 2>/dev/null))"
-    else
-      log_install "Node.js LTS"
-      run_or_dry 'nvm install --lts'
-    fi
-  fi
-}
-
-# ─── uv (Python) ──────────────────────────────────────────────────────────────
-
-install_uv() {
-  if has uv; then
-    record_present "uv ($(version_of uv))"
+  # Cargo tools from declarative list
+  local cargo_file="${CARGO_TOOLS_FILE:-${SCRIPT_DIR:-}/cargo-tools.txt}"
+  if [[ ! -f "$cargo_file" ]]; then
+    echo -e "  ${YELLOW}⚠${RESET} cargo-tools.txt not found, skipping cargo tools"
     return
   fi
-  log_install "uv"
-  run_or_dry 'curl -LsSf https://astral.sh/uv/install.sh | sh'
-}
 
-# ─── Shell Enhancements ───────────────────────────────────────────────────────
+  echo -e "  ${DIM}Using cargo-tools.txt: $cargo_file${RESET}"
 
-install_shell_enhancements() {
-  if [[ "$OS" == "macos" || "$OS" == "linux" ]]; then
-    # oh-my-zsh
-    if [[ -d "${ZSH:-$HOME/.oh-my-zsh}" ]]; then
-      record_present "oh-my-zsh"
+  while IFS= read -r tool; do
+    # Map package name to binary name for checking
+    local cmd="$tool"
+    case "$tool" in
+      git-delta)          cmd="delta" ;;
+      fd-find)            cmd="fd" ;;
+      ripgrep)            cmd="rg" ;;
+      cargo-watch)        cmd="cargo-watch" ;;
+      cargo-mutants)      cmd="cargo-mutants" ;;
+      cargo-semver-checks) cmd="cargo-semver-checks" ;;
+      cargo-nextest)      cmd="cargo-nextest" ;;
+      cargo-edit)         cmd="cargo-add" ;;  # cargo-edit provides cargo-add
+    esac
+
+    if has "$cmd"; then
+      record_present "$tool"
     else
-      log_install "oh-my-zsh"
-      run_or_dry 'sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended'
-    fi
-
-    # Powerlevel10k
-    local p10k_dir="${ZSH_CUSTOM:-${ZSH:-$HOME/.oh-my-zsh}/custom}/themes/powerlevel10k"
-    if [[ -d "$p10k_dir" ]]; then
-      record_present "Powerlevel10k"
-    else
-      log_install "Powerlevel10k"
-      run_or_dry "git clone --depth=1 https://github.com/romkatv/powerlevel10k.git '$p10k_dir'"
-    fi
-
-  elif [[ "$OS" == "windows" ]]; then
-    if [[ -d "${OSH:-$HOME/.oh-my-bash}" ]]; then
-      record_present "oh-my-bash"
-    else
-      log_install "oh-my-bash"
-      run_or_dry 'bash -c "$(curl -fsSL https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh)" --unattended'
-    fi
-  fi
-}
-
-# ─── Main ──────────────────────────────────────────────────────────────────────
-
-main() {
-  detect_platform
-
-  echo ""
-  echo -e "${BOLD}╔══════════════════════════════════════════════╗${RESET}"
-  echo -e "${BOLD}║     iancleary/dotfiles — Tool Installer      ║${RESET}"
-  echo -e "${BOLD}╚══════════════════════════════════════════════╝${RESET}"
-  echo ""
-
-  if $DRY_RUN; then
-    echo -e "  ${YELLOW}DRY RUN${RESET} — no changes will be made"
-    echo ""
-  fi
-
-  echo -e "  Detected: ${BOLD}${OS}${RESET} (${ARCH})"
-
-  if [[ "$OS" == "unknown" ]]; then
-    echo -e "  ${RED}Unsupported operating system${RESET}"
-    exit 1
-  fi
-
-  check_internet
-  echo -e "  Internet: ${GREEN}connected${RESET}"
-
-  # ── Package Manager ──
-  log_section "Package Manager"
-
-  if [[ "$OS" == "macos" || "$OS" == "linux" ]]; then
-    install_homebrew
-  elif [[ "$OS" == "windows" ]]; then
-    install_scoop
-  fi
-
-  # ── Core CLI Tools ──
-  log_section "Core CLI Tools"
-
-  install_cli_tool eza
-  install_cli_tool bat
-  install_cli_tool delta git-delta
-  install_cli_tool zoxide
-  install_cli_tool just
-  install_cli_tool rg ripgrep
-  install_cli_tool lazygit
-  install_cli_tool gum
-  install_cli_tool fd
-  install_cli_tool jq
-
-  if ! $MINIMAL; then
-    # ── Development Tools ──
-    log_section "Development Tools"
-
-    install_cli_tool gh
-    install_rust
-    install_node
-    install_uv
-
-    # ── macOS-only Tools ──
-    if [[ "$OS" == "macos" ]]; then
-      log_section "macOS Tools"
-      install_brew_tool nvim neovim
-      if has ghostty; then
-        record_present "Ghostty"
+      log_install "$tool"
+      if $DRY_RUN; then
+        echo -e " ${DIM}(dry-run)${RESET}"
+        (( COUNT_SKIPPED++ )) || true
       else
-        echo -e "  ${DIM}ℹ Ghostty — install manually from https://ghostty.org${RESET}"
+        cargo install "$tool" &>/dev/null && record_installed || record_failed "$tool" "cargo install failed"
       fi
     fi
+  done < <(read_tool_list "$cargo_file")
+}
 
-    # ── Shell Enhancements ──
-    log_section "Shell Enhancements"
-    install_shell_enhancements
+# ─── Phase 4: Node.js ─────────────────────────────────────────────────────────
+
+install_node() {
+  log_section "Phase 4: Node.js (via nvm)"
+
+  if $SKIP_NODE; then
+    record_skipped "Node.js (--skip-node)"
+    return
+  fi
+
+  if has node; then
+    record_present "Node.js $(node --version 2>/dev/null)"
   else
-    record_skipped "Development tools (--minimal)"
-    record_skipped "Shell enhancements (--minimal)"
+    # Install nvm first
+    if [[ ! -d "$HOME/.nvm" ]]; then
+      log_install "nvm"
+      run_or_dry bash -c 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash' && record_installed || record_failed "nvm" "install failed"
+    else
+      record_present "nvm"
+    fi
+
+    # Install latest LTS
+    if ! $DRY_RUN && [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+      source "$HOME/.nvm/nvm.sh"
+      log_install "Node.js LTS"
+      nvm install --lts &>/dev/null && record_installed || record_failed "Node.js" "nvm install failed"
+    fi
+  fi
+}
+
+# ─── Phase 5: Python (uv) ─────────────────────────────────────────────────────
+
+install_python() {
+  log_section "Phase 5: Python (via uv)"
+
+  if has uv; then
+    record_present "uv $(uv --version 2>/dev/null | awk '{print $2}')"
+  else
+    log_install "uv"
+    run_or_dry bash -c "curl -LsSf https://astral.sh/uv/install.sh | sh" && record_installed || record_failed "uv" "install failed"
+  fi
+}
+
+# ─── Phase 6: Shell Enhancements ──────────────────────────────────────────────
+
+install_shell() {
+  log_section "Phase 6: Shell Enhancements"
+
+  case "$OS" in
+    macos|linux)
+      # oh-my-zsh
+      if [[ -d "$HOME/.oh-my-zsh" ]]; then
+        record_present "oh-my-zsh"
+      else
+        log_install "oh-my-zsh"
+        run_or_dry bash -c 'sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended' && record_installed || record_failed "oh-my-zsh" "install failed"
+      fi
+
+      # Powerlevel10k
+      local p10k_dir="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k"
+      if [[ -d "$p10k_dir" ]]; then
+        record_present "Powerlevel10k"
+      else
+        log_install "Powerlevel10k"
+        run_or_dry git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "$p10k_dir" && record_installed || record_failed "Powerlevel10k" "git clone failed"
+      fi
+      ;;
+    windows)
+      # oh-my-bash
+      if [[ -d "$HOME/.oh-my-bash" ]]; then
+        record_present "oh-my-bash"
+      else
+        log_install "oh-my-bash"
+        run_or_dry bash -c 'bash -c "$(curl -fsSL https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh)" --unattended' && record_installed || record_failed "oh-my-bash" "install failed"
+      fi
+      ;;
+  esac
+}
+
+# ─── Phase 7: Dotfiles Clone & Sync ───────────────────────────────────────────
+
+install_dotfiles() {
+  log_section "Phase 7: Dotfiles Clone & Sync"
+
+  if $SKIP_SYNC; then
+    record_skipped "Dotfiles sync (--skip-sync)"
+    return
   fi
 
-  # ── Summary ──
-  echo ""
-  echo -e "${BOLD}───────────────────────────────────────────────${RESET}"
-  echo -e "${BOLD}Summary${RESET}"
-  echo -e "  Installed:       ${GREEN}${COUNT_INSTALLED}${RESET}"
-  echo -e "  Already present: ${BLUE}${COUNT_PRESENT}${RESET}"
-  echo -e "  Skipped:         ${YELLOW}${COUNT_SKIPPED}${RESET}"
-  echo -e "  Failed:          ${RED}${COUNT_FAILED}${RESET}"
-  echo ""
+  local dotfiles_dir="$HOME/Development/dotfiles"
 
-  if (( COUNT_FAILED > 0 )); then
-    echo -e "  ${RED}Some installations failed. Review the output above.${RESET}"
+  # Clone if not present
+  if [[ -d "$dotfiles_dir/.git" ]]; then
+    record_present "dotfiles repo ($dotfiles_dir)"
+    # Pull latest
+    log_install "dotfiles (pull latest)"
+    if $DRY_RUN; then
+      echo -e " ${DIM}(dry-run)${RESET}"
+    else
+      git -C "$dotfiles_dir" pull --ff-only &>/dev/null && record_installed || record_failed "dotfiles pull" "git pull failed"
+    fi
+  else
+    log_install "dotfiles repo → $dotfiles_dir"
+    if $DRY_RUN; then
+      echo -e " ${DIM}(dry-run)${RESET}"
+    else
+      mkdir -p "$(dirname "$dotfiles_dir")"
+      git clone https://github.com/iancleary/dotfiles.git "$dotfiles_dir" && record_installed || record_failed "dotfiles clone" "git clone failed"
+    fi
+  fi
+
+  # Run sync script
+  local sync_script="$dotfiles_dir/sync-dotfiles.sh"
+  if [[ -x "$sync_script" ]]; then
     echo ""
+    log_install "dotfiles sync (push to \$HOME)"
+    if $DRY_RUN; then
+      echo -e " ${DIM}(dry-run) would run: $sync_script push${RESET}"
+    else
+      "$sync_script" push && record_installed || record_failed "dotfiles sync" "sync push failed"
+    fi
+  else
+    echo -e "  ${YELLOW}⚠${RESET} sync-dotfiles.sh not found or not executable"
+  fi
+}
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+
+print_summary() {
+  echo ""
+  echo -e "${BLUE}──────────────────────────────────────────────────────${RESET}"
+  echo -e "${BOLD}Summary${RESET}"
+  echo ""
+  echo -e "  ${GREEN}Installed:${RESET}       $COUNT_INSTALLED"
+  echo -e "  Already present: $COUNT_PRESENT"
+  echo -e "  Skipped:         $COUNT_SKIPPED"
+  [[ $COUNT_FAILED -gt 0 ]] && echo -e "  ${RED}Failed:          $COUNT_FAILED${RESET}"
+  echo ""
+
+  if [[ $COUNT_FAILED -eq 0 ]]; then
+    echo -e "  ${GREEN}${BOLD}All done!${RESET} 🎉"
+  else
+    echo -e "  ${YELLOW}Done with $COUNT_FAILED failure(s).${RESET} Check output above."
   fi
 
-  echo -e "${BOLD}Next steps:${RESET}"
-  echo -e "  1. Run ${BOLD}./sync-dotfiles.sh push${RESET}   to restore your dotfiles"
-  echo -e "  2. Restart your shell             to pick up new tools"
-  echo -e "  3. Run ${BOLD}just status${RESET}                to verify everything"
-  if ! $MINIMAL && $SKIP_RUST; then
-    :
-  elif ! $MINIMAL; then
-    echo -e "  4. Run ${BOLD}./install-cargo-tools.sh${RESET}  to install cargo extras (optional)"
-  fi
+  echo ""
+  echo -e "  ${DIM}Next steps:${RESET}"
+  echo -e "  ${DIM}  1. Restart your shell to pick up new tools${RESET}"
+  echo -e "  ${DIM}  2. Run 'just status' in ~/Development/dotfiles to verify${RESET}"
   echo ""
 }
 
-main
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+# Resolve script dir (empty if running from curl pipe)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" 2>/dev/null)" 2>/dev/null && pwd)" || SCRIPT_DIR=""
+CARGO_TOOLS_FILE=""
+
+detect_platform
+print_banner
+install_package_manager
+install_system_tools
+install_rust
+install_node
+install_python
+install_shell
+install_dotfiles
+print_summary

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@
 # Options:
 #   --dry-run    Show what would be installed without installing
 #   --skip-rust  Skip Rust toolchain + cargo tools
+#   --skip-go    Skip Go toolchain + go install tools
 #   --skip-node  Skip Node.js/nvm installation
 #   --skip-sync  Skip dotfiles clone and sync
 
@@ -19,6 +20,7 @@ set -euo pipefail
 
 DRY_RUN=false
 SKIP_RUST=false
+SKIP_GO=false
 SKIP_NODE=false
 SKIP_SYNC=false
 
@@ -26,6 +28,7 @@ for arg in "$@"; do
   case "$arg" in
     --dry-run)    DRY_RUN=true ;;
     --skip-rust)  SKIP_RUST=true ;;
+    --skip-go)    SKIP_GO=true ;;
     --skip-node)  SKIP_NODE=true ;;
     --skip-sync)  SKIP_SYNC=true ;;
     --help|-h)
@@ -185,9 +188,11 @@ install_system_tools() {
     curl -fsSL "https://raw.githubusercontent.com/iancleary/dotfiles/main/Brewfile" -o "$tmpdir/Brewfile"
     curl -fsSL "https://raw.githubusercontent.com/iancleary/dotfiles/main/Scoopfile.json" -o "$tmpdir/Scoopfile.json"
     curl -fsSL "https://raw.githubusercontent.com/iancleary/dotfiles/main/cargo-tools.txt" -o "$tmpdir/cargo-tools.txt"
+    curl -fsSL "https://raw.githubusercontent.com/iancleary/dotfiles/main/go-tools.txt" -o "$tmpdir/go-tools.txt"
     brewfile="$tmpdir/Brewfile"
     scoopfile="$tmpdir/Scoopfile.json"
     CARGO_TOOLS_FILE="$tmpdir/cargo-tools.txt"
+    GO_TOOLS_FILE="$tmpdir/go-tools.txt"
   fi
 
   case "$OS" in
@@ -282,16 +287,86 @@ install_rust() {
         echo -e " ${DIM}(dry-run)${RESET}"
         (( COUNT_SKIPPED++ )) || true
       else
-        cargo install "$tool" &>/dev/null && record_installed || record_failed "$tool" "cargo install failed"
+        cargo install --locked "$tool" &>/dev/null && record_installed || record_failed "$tool" "cargo install failed"
       fi
     fi
   done < <(read_tool_list "$cargo_file")
 }
 
-# ─── Phase 4: Node.js ─────────────────────────────────────────────────────────
+# ─── Phase 4: Go + Go Tools ───────────────────────────────────────────────────
+
+install_go() {
+  log_section "Phase 4: Go Toolchain + Go Tools"
+
+  if $SKIP_GO; then
+    record_skipped "Go (--skip-go)"
+    return
+  fi
+
+  # Install Go toolchain
+  if has go; then
+    record_present "Go $(go version 2>/dev/null | awk '{print $3}' | sed 's/go//')"
+  else
+    log_install "Go"
+    if $DRY_RUN; then
+      echo -e " ${DIM}(dry-run)${RESET}"
+      (( COUNT_SKIPPED++ )) || true
+    else
+      case "$OS" in
+        macos)
+          brew install go &>/dev/null && record_installed || record_failed "Go" "brew install failed"
+          ;;
+        linux)
+          # Download latest Go from official tarball
+          local go_version
+          go_version=$(curl -fsSL "https://go.dev/VERSION?m=text" | head -1)
+          local go_arch="amd64"
+          [[ "$ARCH" == "arm64" ]] && go_arch="arm64"
+          curl -fsSL "https://go.dev/dl/${go_version}.linux-${go_arch}.tar.gz" | sudo tar -C /usr/local -xzf - && record_installed || record_failed "Go" "tarball install failed"
+          export PATH="/usr/local/go/bin:$PATH"
+          ;;
+        windows)
+          scoop install go &>/dev/null && record_installed || record_failed "Go" "scoop install failed"
+          ;;
+      esac
+    fi
+  fi
+
+  # Ensure GOPATH/bin is on PATH for this session
+  export PATH="${GOPATH:-$HOME/go}/bin:$PATH"
+
+  # Go tools from declarative list
+  local go_file="${GO_TOOLS_FILE:-${SCRIPT_DIR:-}/go-tools.txt}"
+  if [[ ! -f "$go_file" ]]; then
+    echo -e "  ${YELLOW}⚠${RESET} go-tools.txt not found, skipping go tools"
+    return
+  fi
+
+  echo -e "  ${DIM}Using go-tools.txt: $go_file${RESET}"
+
+  while IFS= read -r module; do
+    # Extract binary name from module path (last path segment, strip @version)
+    local cmd
+    cmd=$(basename "${module%%@*}")
+
+    if has "$cmd"; then
+      record_present "$cmd"
+    else
+      log_install "$cmd"
+      if $DRY_RUN; then
+        echo -e " ${DIM}(dry-run)${RESET}"
+        (( COUNT_SKIPPED++ )) || true
+      else
+        go install "$module" &>/dev/null && record_installed || record_failed "$cmd" "go install failed"
+      fi
+    fi
+  done < <(read_tool_list "$go_file")
+}
+
+# ─── Phase 5: Node.js ─────────────────────────────────────────────────────────
 
 install_node() {
-  log_section "Phase 4: Node.js (via nvm)"
+  log_section "Phase 5: Node.js (via nvm)"
 
   if $SKIP_NODE; then
     record_skipped "Node.js (--skip-node)"
@@ -318,10 +393,10 @@ install_node() {
   fi
 }
 
-# ─── Phase 5: Python (uv) ─────────────────────────────────────────────────────
+# ─── Phase 6: Python (uv) ─────────────────────────────────────────────────────
 
 install_python() {
-  log_section "Phase 5: Python (via uv)"
+  log_section "Phase 6: Python (via uv)"
 
   if has uv; then
     record_present "uv $(uv --version 2>/dev/null | awk '{print $2}')"
@@ -331,10 +406,10 @@ install_python() {
   fi
 }
 
-# ─── Phase 6: Shell Enhancements ──────────────────────────────────────────────
+# ─── Phase 7: Shell Enhancements ──────────────────────────────────────────────
 
 install_shell() {
-  log_section "Phase 6: Shell Enhancements"
+  log_section "Phase 7: Shell Enhancements"
 
   case "$OS" in
     macos|linux)
@@ -367,10 +442,10 @@ install_shell() {
   esac
 }
 
-# ─── Phase 7: Dotfiles Clone & Sync ───────────────────────────────────────────
+# ─── Phase 8: Dotfiles Clone & Sync ───────────────────────────────────────────
 
 install_dotfiles() {
-  log_section "Phase 7: Dotfiles Clone & Sync"
+  log_section "Phase 8: Dotfiles Clone & Sync"
 
   if $SKIP_SYNC; then
     record_skipped "Dotfiles sync (--skip-sync)"
@@ -445,12 +520,14 @@ print_summary() {
 # Resolve script dir (empty if running from curl pipe)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" 2>/dev/null)" 2>/dev/null && pwd)" || SCRIPT_DIR=""
 CARGO_TOOLS_FILE=""
+GO_TOOLS_FILE=""
 
 detect_platform
 print_banner
 install_package_manager
 install_system_tools
 install_rust
+install_go
 install_node
 install_python
 install_shell

--- a/justfile
+++ b/justfile
@@ -17,3 +17,16 @@ push:
 # Show diff between home and repo
 status:
     ./sync-dotfiles.sh status
+
+# Install all tools (core + dev)
+install *ARGS:
+    ./install.sh {{ARGS}}
+
+# Install cargo-based tools (slower, optional)
+install-cargo *ARGS:
+    ./install-cargo-tools.sh {{ARGS}}
+
+# Install everything (tools + cargo extras)
+install-all *ARGS:
+    ./install.sh {{ARGS}}
+    ./install-cargo-tools.sh {{ARGS}}


### PR DESCRIPTION
Adds a Determinate Systems-style installer script for setting up a new machine with all tools from the dotfiles.

## What's included

- **`install.sh`** — Main installer: detects OS/arch, installs Homebrew/Scoop, all CLI tools, Rust, Node/nvm, uv, shell enhancements. Idempotent, colorful output, supports `--dry-run`, `--minimal`, `--skip-rust`, `--skip-node`.
- **`install-cargo-tools.sh`** — Separate script for cargo-installed tools (cargo-watch, cargo-mutants, cargo-semver-checks, cargo-edit)
- **justfile** — Added `install`, `install-cargo`, `install-all` recipes
- **README** — Added Automated Installation section

## Usage

```bash
curl -fsSL https://raw.githubusercontent.com/iancleary/dotfiles/main/install.sh | bash
```

Tested with `--dry-run` on macOS arm64 — detects 14 already-installed tools correctly.